### PR TITLE
REF: Use NumpyEncoder from event-model rather than copy/paste.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # List required packages in this file, one per line.
 event-model >=1.8.0rc1
-numpy
 suitcase-utils

--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -2,7 +2,6 @@ import event_model
 from pathlib import Path
 import suitcase.utils
 from ._version import get_versions
-import numpy
 import json
 
 __version__ = get_versions()['version']

--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -9,18 +9,8 @@ __version__ = get_versions()['version']
 del get_versions
 
 
-class NumpyEncoder(json.JSONEncoder):
-    # Credit: https://stackoverflow.com/a/47626762/1221924
-    def default(self, obj):
-        if isinstance(obj, (numpy.generic, numpy.ndarray)):
-            if numpy.isscalar(obj):
-                return obj.item()
-            return obj.tolist()
-        return json.JSONEncoder.default(self, obj)
-
-
 def export(gen, directory, file_prefix='{uid}',
-           cls=NumpyEncoder, **kwargs):
+           cls=event_model.NumpyEncoder, **kwargs):
     serializer = Serializer(directory, file_prefix, cls=cls, **kwargs)
     try:
         for item in gen:
@@ -32,7 +22,7 @@ def export(gen, directory, file_prefix='{uid}',
 
 class Serializer(event_model.DocumentRouter):
     def __init__(self, directory, file_prefix='{uid}',
-                 cls=NumpyEncoder, **kwargs):
+                 cls=event_model.NumpyEncoder, **kwargs):
 
         self._output_file = None
         self._file_prefix = file_prefix

--- a/suitcase/jsonl/tests.py
+++ b/suitcase/jsonl/tests.py
@@ -1,5 +1,6 @@
 import json
-from suitcase.jsonl import export, NumpyEncoder
+from event_model import NumpyEncoder
+from suitcase.jsonl import export
 
 
 def test_export(tmp_path, example_data):


### PR DESCRIPTION
As of event-model 1.8.0rc2, `NumpyEncoder` is available there. Might as well import it so that any future improvements/fixes will automatically propagate here.