### PR TITLE
Label artifact as 'all'.

### DIFF
--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -52,7 +52,7 @@ class Serializer(event_model.DocumentRouter):
 
     def _get_file(self):
         filename = (f'{self._templated_file_prefix}.jsonl')
-        self._output_file = self._manager.open('stream_data', filename, 'xt')
+        self._output_file = self._manager.open('all', filename, 'xt')
 
     def __call__(self, name, doc):
         if name == 'start':

--- a/suitcase/jsonl/tests/tests.py
+++ b/suitcase/jsonl/tests/tests.py
@@ -6,7 +6,7 @@ from suitcase.jsonl import export
 def test_export(tmp_path, example_data):
     documents = example_data()
     artifacts = export(documents, tmp_path)
-    filepath, = artifacts['stream_data']
+    filepath, = artifacts['all']
     with open(filepath) as file:
         actual = [json.loads(line) for line in file]
     expected = [json.loads(json.dumps(doc, cls=NumpyEncoder))


### PR DESCRIPTION
The current choice, ``'stream_data'`` was copied over from suitcase-csv,
where indeed only the *data* from a stream is being written. In this case we
are writing everything. The term ``'all'`` has the virtue of being short and I
think pretty clear. Terms currently in use are:

* stream_data
* run_metadata