### PR TITLE
FIX: Adding docstrings to export and Serializer

### DIFF
--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -39,12 +39,11 @@ def export(gen, directory, file_prefix='{uid}',
         (http://nsls-ii.github.io/suitcase) for details.
     file_prefix : str, optional
         The first part of the filename of the generated output files. This
-        string may include templates as in
-        ``{start[proposal_id]}-{start[sample_name]}-``, which are populated
-        from the RunStart (start), EventDescriptor (descriptor) or Event
-        (event) documents. The default value is ``{start[uid]}-`` which is
-        guaranteed to be present and unique. A more descriptive value depends
-        on the application and is therefore left to the user.
+        string may include templates as in ``{proposal_id}-{sample_name}-``,
+        which are populated from the RunStart document. The default value is
+        ``{uid}`` which is guaranteed to be present and unique. A more
+        descriptive value depends on the application and is therefore left to
+        the user.
     cls : Encoder class, optional
         A ``json.JSONEncoder`` class that is used for parsing the documents
         into valid json objects. The default is ``event_model.NumpyEncoder``
@@ -62,12 +61,15 @@ def export(gen, directory, file_prefix='{uid}',
     >>> export(gen, '')
 
     Generate files with more readable metadata in the file names.
-    >>> export(gen, '', '{start[plan_name]}-{start[motors]}-')
+
+    >>> export(gen, '', '{plan_name}-{motors}-')
 
     Include the experiment's start time formatted as YYYY-MM-DD_HH-MM.
-    >>> export(gen, '', '{start[time]:%Y-%m-%d_%H:%M}-')
+
+    >>> export(gen, '', '{time:%Y-%m-%d_%H:%M}-')
 
     Place the files in a different directory, such as on a mounted USB stick.
+
     >>> export(gen, '/path/to/my_usb_stick')
     """
 
@@ -105,12 +107,11 @@ class Serializer(event_model.DocumentRouter):
         (http://nsls-ii.github.io/suitcase) for details.
     file_prefix : str, optional
         The first part of the filename of the generated output files. This
-        string may include templates as in
-        ``{start[proposal_id]}-{start[sample_name]}-``, which are populated
-        from the RunStart (start), EventDescriptor (descriptor) or Event
-        (event) documents. The default value is ``{start[uid]}-`` which is
-        guaranteed to be present and unique. A more descriptive value depends
-        on the application and is therefore left to the user.
+        string may include templates as in ``{proposal_id}-{sample_name}-``,
+        which are populated from the RunStart document. The default value is
+        ``{uid}`` which is guaranteed to be present and unique. A more
+        descriptive value depends on the application and is therefore left to
+        the user.
     cls : Encoder class, optional
         A ``json.JSONEncoder`` class that is used for parsing the documents
         into valid json objects. The default is ``event_model.NumpyEncoder``
@@ -123,12 +124,15 @@ class Serializer(event_model.DocumentRouter):
     >>> export(gen, '')
 
     Generate files with more readable metadata in the file names.
-    >>> export(gen, '', '{start[plan_name]}-{start[motors]}-')
+
+    >>> export(gen, '', '{plan_name}-{motors}-')
 
     Include the experiment's start time formatted as YYYY-MM-DD_HH-MM.
-    >>> export(gen, '', '{start[time]:%Y-%m-%d_%H:%M}-')
+
+    >>> export(gen, '', '{time:%Y-%m-%d_%H:%M}-')
 
     Place the files in a different directory, such as on a mounted USB stick.
+
     >>> export(gen, '/path/to/my_usb_stick')
     """
 

--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -12,14 +12,17 @@ def export(gen, directory, file_prefix='{uid}',
            cls=event_model.NumpyEncoder, **kwargs):
 
     """
-    Export a stream of documents to a json line delimited file.
+    Export a stream of documents to a newline-delimited JSON file.
 
-    All documents are recorded as seperate lines with the form (name, doc) This
-    creates a file named: ``<directory>/<file_prefix>.jsonl``
+    All documents are recorded as seperate lines with the form [name, doc].
+    This creates a file named: ``<directory>/<file_prefix>.jsonl``
+
     .. note::
+
         This can alternatively be used to write data to generic buffers rather
         than creating files on disk. See the documentation for the
         ``directory`` parameter below.
+
     Parameters
     ----------
     gen : generator

--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -10,6 +10,64 @@ del get_versions
 
 def export(gen, directory, file_prefix='{uid}',
            cls=event_model.NumpyEncoder, **kwargs):
+
+    """
+    Export a stream of documents to a json line delimited file.
+
+    All documents are recorded as seperate lines with the form (name, doc) This
+    creates a file named: ``<directory>/<file_prefix>.jsonl``
+    .. note::
+        This can alternatively be used to write data to generic buffers rather
+        than creating files on disk. See the documentation for the
+        ``directory`` parameter below.
+    Parameters
+    ----------
+    gen : generator
+        expected to yield ``(name, document)`` pairs
+    directory : string, Path or Manager.
+        For basic uses, this should be the path to the output directory given
+        as a string or Path object. Use an empty string ``''`` to place files
+        in the current working directory.
+        In advanced applications, this may direct the serialized output to a
+        memory buffer, network socket, or other writable buffer. It should be
+        an instance of ``suitcase.utils.MemoryBufferManager`` and
+        ``suitcase.utils.MultiFileManager`` or any object implementing that
+        interface. See the suitcase documentation
+        (http://nsls-ii.github.io/suitcase) for details.
+    file_prefix : str, optional
+        The first part of the filename of the generated output files. This
+        string may include templates as in
+        ``{start[proposal_id]}-{start[sample_name]}-``, which are populated
+        from the RunStart (start), EventDescriptor (descriptor) or Event
+        (event) documents. The default value is ``{start[uid]}-`` which is
+        guaranteed to be present and unique. A more descriptive value depends
+        on the application and is therefore left to the user.
+    cls : Encoder class, optional
+        A ``json.JSONEncoder`` class that is used for parsing the documents
+        into valid json objects. The default is ``event_model.NumpyEncoder``
+        which also converts all numpy objects into built-in python objects.
+
+    Returns
+    -------
+    dest : dict
+        dict mapping the 'labels' to lists of file names
+
+    Examples
+    --------
+    Generate files with unique-identifier names in the current directory.
+
+    >>> export(gen, '')
+
+    Generate files with more readable metadata in the file names.
+    >>> export(gen, '', '{start[plan_name]}-{start[motors]}-')
+
+    Include the experiment's start time formatted as YYYY-MM-DD_HH-MM.
+    >>> export(gen, '', '{start[time]:%Y-%m-%d_%H:%M}-')
+
+    Place the files in a different directory, such as on a mounted USB stick.
+    >>> export(gen, '/path/to/my_usb_stick')
+    """
+
     with Serializer(directory, file_prefix, cls=cls, **kwargs) as serializer:
         for item in gen:
             serializer(*item)
@@ -18,6 +76,64 @@ def export(gen, directory, file_prefix='{uid}',
 
 
 class Serializer(event_model.DocumentRouter):
+
+    """
+    Serialize a stream of documents to a json line delimited file.
+
+    All documents are recorded as seperate lines with the form (name, doc) This
+    creates a file named: ``<directory>/<file_prefix>.jsonl``
+    .. note::
+        This can alternatively be used to write data to generic buffers rather
+        than creating files on disk. See the documentation for the
+        ``directory`` parameter below.
+    Parameters
+    ----------
+    gen : generator
+        expected to yield ``(name, document)`` pairs
+    directory : string, Path or Manager.
+        For basic uses, this should be the path to the output directory given
+        as a string or Path object. Use an empty string ``''`` to place files
+        in the current working directory.
+        In advanced applications, this may direct the serialized output to a
+        memory buffer, network socket, or other writable buffer. It should be
+        an instance of ``suitcase.utils.MemoryBufferManager`` and
+        ``suitcase.utils.MultiFileManager`` or any object implementing that
+        interface. See the suitcase documentation
+        (http://nsls-ii.github.io/suitcase) for details.
+    file_prefix : str, optional
+        The first part of the filename of the generated output files. This
+        string may include templates as in
+        ``{start[proposal_id]}-{start[sample_name]}-``, which are populated
+        from the RunStart (start), EventDescriptor (descriptor) or Event
+        (event) documents. The default value is ``{start[uid]}-`` which is
+        guaranteed to be present and unique. A more descriptive value depends
+        on the application and is therefore left to the user.
+    cls : Encoder class, optional
+        A ``json.JSONEncoder`` class that is used for parsing the documents
+        into valid json objects. The default is ``event_model.NumpyEncoder``
+        which also converts all numpy objects into built-in python objects.
+
+    Returns
+    -------
+    dest : dict
+        dict mapping the 'labels' to lists of file names
+
+    Examples
+    --------
+    Generate files with unique-identifier names in the current directory.
+
+    >>> export(gen, '')
+
+    Generate files with more readable metadata in the file names.
+    >>> export(gen, '', '{start[plan_name]}-{start[motors]}-')
+
+    Include the experiment's start time formatted as YYYY-MM-DD_HH-MM.
+    >>> export(gen, '', '{start[time]:%Y-%m-%d_%H:%M}-')
+
+    Place the files in a different directory, such as on a mounted USB stick.
+    >>> export(gen, '/path/to/my_usb_stick')
+    """
+
     def __init__(self, directory, file_prefix='{uid}',
                  cls=event_model.NumpyEncoder, **kwargs):
 

--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -113,11 +113,6 @@ class Serializer(event_model.DocumentRouter):
         into valid json objects. The default is ``event_model.NumpyEncoder``
         which also converts all numpy objects into built-in python objects.
 
-    Returns
-    -------
-    dest : dict
-        dict mapping the 'labels' to lists of file names
-
     Examples
     --------
     Generate files with unique-identifier names in the current directory.

--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -52,8 +52,8 @@ def export(gen, directory, file_prefix='{uid}',
 
     Returns
     -------
-    dest : dict
-        dict mapping the 'labels' to lists of file names
+    artifacts : dict
+        Maps 'labels' to lists of artifacts (e.g. filepaths)
 
     Examples
     --------


### PR DESCRIPTION
This PR adds docstrings to `export` and `Serializer` in `__init__.py` 